### PR TITLE
feat(verif-cb): ajouter la gestion des personnes morales ou physiques

### DIFF
--- a/src/DTO/BankAccountOwner.php
+++ b/src/DTO/BankAccountOwner.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComCompany\YousignBundle\DTO;
+
+class BankAccountOwner
+{
+    private ?NaturalPerson $naturalPerson;
+    private ?LegalPerson $legalPerson;
+
+    private function __construct(?NaturalPerson $naturalPerson, ?LegalPerson $legalPerson)
+    {
+        $this->naturalPerson = $naturalPerson;
+        $this->legalPerson = $legalPerson;
+    }
+
+    public static function fromNaturalPerson(NaturalPerson $person): self
+    {
+        return new self($person, null);
+    }
+
+    public static function fromLegalPerson(LegalPerson $person): self
+    {
+        return new self(null, $person);
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        if ($this->naturalPerson !== null) {
+            return ['natural_person' => $this->naturalPerson->toArray()];
+        }
+
+        return ['legal_person' => $this->legalPerson->toArray()];
+    }
+}

--- a/src/DTO/LegalPerson.php
+++ b/src/DTO/LegalPerson.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComCompany\YousignBundle\DTO;
+
+class LegalPerson
+{
+    private string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray()
+    {
+        return [
+            'name' => $this->name,
+        ];
+    }
+}

--- a/src/DTO/NaturalPerson.php
+++ b/src/DTO/NaturalPerson.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComCompany\YousignBundle\DTO;
+
+class NaturalPerson
+{
+    private string $firstName;
+    private string $lastName;
+
+    public function __construct(string $firstName, string $lastName)
+    {
+        $this->firstName = $firstName;
+        $this->lastName = $lastName;
+    }
+
+    public function getFirstName(): string
+    {
+        return $this->firstName;
+    }
+
+    public function getLastName(): string
+    {
+        return $this->lastName;
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        return [
+            'first_name' => $this->firstName,
+            'last_name'  => $this->lastName,
+        ];
+    }
+}

--- a/src/Service/ClientInterface.php
+++ b/src/Service/ClientInterface.php
@@ -2,6 +2,7 @@
 
 namespace ComCompany\YousignBundle\Service;
 
+use ComCompany\YousignBundle\DTO\BankAccountOwner;
 use ComCompany\YousignBundle\DTO\Document;
 use ComCompany\YousignBundle\DTO\Field\Field;
 use ComCompany\YousignBundle\DTO\FieldsLocations;
@@ -113,7 +114,7 @@ interface ClientInterface
      *
      * @return string verification id
      */
-    public function startBankAccountDocVerification(Document $document, ?string $iban = null, ?string $bic = null): string;
+    public function startBankAccountDocVerification(Document $document, ?string $iban = null, ?string $bic = null, ?BankAccountOwner $owner = null): string;
 
     public function getBankAccountDocVerification(string $verificationId): string;
 }

--- a/src/Service/YousignClient.php
+++ b/src/Service/YousignClient.php
@@ -3,6 +3,7 @@
 namespace ComCompany\YousignBundle\Service;
 
 use ComCompany\YousignBundle\Constants\Versions;
+use ComCompany\YousignBundle\DTO\BankAccountOwner;
 use ComCompany\YousignBundle\DTO\Document;
 use ComCompany\YousignBundle\DTO\Field\Field;
 use ComCompany\YousignBundle\DTO\FieldsLocations;
@@ -118,9 +119,9 @@ class YousignClient implements ClientInterface
         $this->getInstance($version)->sendReminder($procedureId, $signerId);
     }
 
-    public function startBankAccountDocVerification(Document $document, ?string $iban = null, ?string $bic = null, string $version = Versions::V3): string
+    public function startBankAccountDocVerification(Document $document, ?string $iban = null, ?string $bic = null, ?BankAccountOwner $owner = null, string $version = Versions::V3): string
     {
-        return $this->getInstance($version)->startBankAccountDocVerification($document, $iban, $bic);
+        return $this->getInstance($version)->startBankAccountDocVerification($document, $iban, $bic, $owner);
     }
 
     public function getBankAccountDocVerification(string $verificationId, string $version = Versions::V3): string

--- a/src/Service/YousignV2/ClientYousign.php
+++ b/src/Service/YousignV2/ClientYousign.php
@@ -2,6 +2,7 @@
 
 namespace ComCompany\YousignBundle\Service\YousignV2;
 
+use ComCompany\YousignBundle\DTO\BankAccountOwner;
 use ComCompany\YousignBundle\DTO\Document;
 use ComCompany\YousignBundle\DTO\Field\Field;
 use ComCompany\YousignBundle\DTO\FieldsLocations;
@@ -254,7 +255,7 @@ class ClientYousign implements ClientInterface
         throw new ClientException("'sendReminder' method is not supported in Yousing v2.", 501);
     }
 
-    public function startBankAccountDocVerification(Document $document, ?string $iban = null, ?string $bic = null): string
+    public function startBankAccountDocVerification(Document $document, ?string $iban = null, ?string $bic = null, ?BankAccountOwner $owner = null): string
     {
         throw new ClientException("'startBankAccountDocVerification' method is not available for Yousing v2.", 501);
     }

--- a/src/Service/YousignV3/ClientYousign.php
+++ b/src/Service/YousignV3/ClientYousign.php
@@ -2,6 +2,7 @@
 
 namespace ComCompany\YousignBundle\Service\YousignV3;
 
+use ComCompany\YousignBundle\DTO\BankAccountOwner;
 use ComCompany\YousignBundle\DTO\Document;
 use ComCompany\YousignBundle\DTO\Field\Field;
 use ComCompany\YousignBundle\DTO\FieldsLocations;
@@ -589,8 +590,12 @@ class ClientYousign implements ClientInterface
         }
     }
 
-    public function startBankAccountDocVerification(Document $document, ?string $iban = null, ?string $bic = null): string
-    {
+    public function startBankAccountDocVerification(
+        Document $document,
+        ?string $iban = null,
+        ?string $bic = null,
+        ?BankAccountOwner $owner = null
+    ): string {
         $file = new \SplFileInfo($document->getPath());
         $params = [
             'file' => DataPart::fromPath($file->getPathname(), $document->getName(), $document->getMimeType()),
@@ -602,6 +607,10 @@ class ClientYousign implements ClientInterface
 
         if ($bic !== null) {
             $params['bic'] = $bic;
+        }
+
+        if ($owner !== null) {
+            $params = array_merge($params, $owner->toArray());
         }
 
         $formData = new FormDataPart($params);


### PR DESCRIPTION
Pour utiliser les personnes morales ou physiques sur la vérification voici un exemple;
`$this->bankAccountVerification->startBankAccountDocVerification($uploadedoc, 'FR7612XXXXXXXXXX', 'AGRIFRXXXXX', BankAccountOwner::fromNaturalPerson(new NaturalPerson('John', 'Doe')));`

Doc: https://developers.yousign.com/reference/post-verifications-bank_accounts